### PR TITLE
update compose file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Database Config
+POSTGRES_DB=acm
+POSTGRES_USER=acmsecy
+POSTGRES_PASSWORD=acmheads
+
+# SMTP Config (for sending emails)
+SMTP_EMAIL=your_email@gmail.com
+SMTP_PASSWORD=your_password

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ Backend of the official website of PEC ACM CSS
 
 > You need Intellij IDEA Ultimate, avail it by student discount
 
+### For Frontend Development (Docker)
+
+1. Create `.env` file:
+   ```bash
+   cp .env.example .env
+   ```
+   Edit `.env` with your credentials (especially POSTGRES_PASSWORD and SMTP credentials)
+
+2. Start the backend:
+   ```bash
+   docker-compose up -d
+   ```
+
+3. Backend is now running at: `http://localhost:8080`
+
+4. When done, stop the backend:
+   ```bash
+   docker-compose stop
+   ```
+
+> [!WARNING]
+> Use `docker-compose stop` to pause services. Only use `docker-compose down` if you want to completely remove containers and networks. Use `docker-compose down -v` to also remove database data (full reset).
+
 ## Instructions
 
 - Always work in separate branch for each feature.

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,10 +6,16 @@ services:
       - POSTGRES_DB=acm
       - POSTGRES_USER=acmsecy
       - POSTGRES_PASSWORD=acmheads
-    ports:
-      - "5432:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U acmsecy -d acm"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - acm-network
+
 
   backend:
     image : 6791042/seed-acm-backend:latest
@@ -23,7 +29,15 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - postgres-database
+      postgres-database:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - acm-network
 
 volumes:
   db-data:
+
+networks:
+  acm-network:
+    driver: bridge

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,9 +3,9 @@ services:
     image: 'postgres:15'
     container_name: postgres-database
     environment:
-      - POSTGRES_DB=acm
-      - POSTGRES_USER=acmsecy
-      - POSTGRES_PASSWORD=acmheads
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - db-data:/var/lib/postgresql/data
     healthcheck:
@@ -21,11 +21,11 @@ services:
     image : 6791042/seed-acm-backend:latest
     container_name: acm-backend
     environment:
-      - POSTGRESQL_DB_URL=jdbc:postgresql://postgres-database:5432/acm
-      - POSTGRESQL_DB_USER=acmsecy
-      - POSTGRESQL_DB_PASSWORD=acmheads
-      - SMTP_EMAIL=youremail@gmail.com
-      - SMTP_PASSWORD=yourpassword
+      - POSTGRESQL_DB_URL=jdbc:postgresql://postgres-database:5432/${POSTGRES_DB}
+      - POSTGRESQL_DB_USER=${POSTGRES_USER}
+      - POSTGRESQL_DB_PASSWORD=${POSTGRES_PASSWORD}
+      - SMTP_EMAIL=${SMTP_EMAIL}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
This PR fixes the race-condition where the backends start before the db container, resulting in the backend panicking and exiting early.

## what does this do?
- add health check for db server
- start backend only after the health-check for db passes
  - add a restart so that the backend keeps re-starting itself in case of errors (unless stopped by the user)
- create a network bridge to connect backend and db
- remove exposing db's network ports. 
- move database and smtp credentials to `.env` file instead of hardcoding.
- update readme to include frontend development instructions

## how to test?

- Compose file changes
  1. clone the repo
  2. checkout `savy/compose` branch
  3. set required env vars
  4. run `docker compose up` to run the container.
     - Optionally pass the `-d` flag to run the container in daemon mode.
  5. the backend should be running and listen for requests at port `8080`
- README updates
  1. just open the readme and check `For Frontend Development (Docker)` section